### PR TITLE
feat: publish device on the LAN via mDNS / Bonjour

### DIFF
--- a/BoundaryConfig.h
+++ b/BoundaryConfig.h
@@ -23,6 +23,7 @@
 #include <WiFi.h>
 #include <WebServer.h>
 #include <DNSServer.h>
+#include "MdnsService.h"
 
 // ─── Node hash (cached in RTC by normal boot, read here without starting RNS) ─
 #define NODE_HASH_RTC_MAGIC  0x504B4841UL
@@ -161,6 +162,33 @@ static void config_send_html() {
         "<input name='node_name' maxlength='32' placeholder='e.g. My RNode' value='"
     );
     html += String(boundary_state.node_name);
+    html += F("'>");
+
+    // ── mDNS Hostname Section ──
+    html += F(
+        "<h2>&#x1f310; Local Network Name (mDNS)</h2>"
+        "<p class='note'>Publishes the device on the local network so you can reach it as "
+        "<code>&lt;name&gt;.local</code> from any computer in your LAN without knowing its IP. "
+        "Disable to suppress all multicast announcements.</p>"
+        "<label>mDNS</label>"
+        "<select name='mdns_en'>"
+    );
+    html += F("<option value='1'");
+    if (boundary_state.mdns_enabled) html += F(" selected");
+    html += F(">Enabled</option>");
+    html += F("<option value='0'");
+    if (!boundary_state.mdns_enabled) html += F(" selected");
+    html += F(">Disabled</option>");
+    html += F("</select>");
+
+    html += F(
+        "<label>Hostname</label>"
+        "<p class='note'>Leave blank for the default <code>rtnode&lt;XXXX&gt;.local</code> "
+        "(last 4 hex chars of the device MAC). "
+        "Allowed: lowercase letters, digits and hyphens; first/last char must be alphanumeric.</p>"
+        "<input name='mdns_name' maxlength='32' placeholder='rtnode' value='"
+    );
+    html += String(boundary_state.mdns_hostname);
     html += F("'>");
 
     html += F(
@@ -603,6 +631,37 @@ static void config_handle_save() {
     memset(boundary_state.node_name, 0, sizeof(boundary_state.node_name));
     strncpy(boundary_state.node_name, node_name_arg.c_str(), sizeof(boundary_state.node_name) - 1);
 
+    // ── mDNS enable + hostname ──
+    {
+        boundary_state.mdns_enabled = (config_server->arg("mdns_en").toInt() != 0);
+    }
+    // Lowercase, strip whitespace, allow only [a-z0-9-]; reject leading/trailing
+    // hyphens. Empty input falls back to the auto-generated `rtnode<XXXX>` at
+    // mDNS start time.
+    {
+        String mdns_arg = config_server->arg("mdns_name");
+        mdns_arg.trim();
+        mdns_arg.toLowerCase();
+        char clean[33];
+        size_t j = 0;
+        for (size_t i = 0; i < mdns_arg.length() && j < sizeof(clean) - 1; i++) {
+            char c = mdns_arg.charAt(i);
+            if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+                clean[j++] = c;
+            }
+        }
+        clean[j] = '\0';
+        // Strip leading/trailing hyphens to keep RFC-952-ish compliance.
+        while (j > 0 && clean[j - 1] == '-') clean[--j] = '\0';
+        size_t start = 0;
+        while (clean[start] == '-') start++;
+        memset(boundary_state.mdns_hostname, 0, sizeof(boundary_state.mdns_hostname));
+        if (clean[start] != '\0') {
+            strncpy(boundary_state.mdns_hostname, clean + start,
+                    sizeof(boundary_state.mdns_hostname) - 1);
+        }
+    }
+
     // Save boundary config to EEPROM
     boundary_save_config();
 
@@ -732,6 +791,10 @@ void config_portal_start() {
 
     Serial.println("[Config] Starting configuration portal...");
 
+    // Tear down any STA-mode mDNS before flipping the radio to AP — the
+    // ESPmDNS state must not survive a WiFi mode change.
+    mdns_service::stop();
+
     // Stop any existing WiFi
     WiFi.softAPdisconnect(true);
     WiFi.disconnect(true, true);
@@ -762,6 +825,12 @@ void config_portal_start() {
     config_server->on("/save", HTTP_POST, config_handle_save);
     config_server->onNotFound(config_handle_redirect);  // Captive portal catch-all
     config_server->begin();
+
+    // Publish a stable .local name so users don't need to remember the AP IP.
+    // Captive portal still works via DNSServer for clients without mDNS.
+    if (boundary_state.mdns_enabled) {
+        mdns_service::start_ap_config("rtnode");
+    }
 
     config_portal_active = true;
 
@@ -806,6 +875,8 @@ void config_portal_stop() {
         delete config_dns;
         config_dns = nullptr;
     }
+
+    mdns_service::stop();
 
     WiFi.softAPdisconnect(true);
     WiFi.mode(WIFI_MODE_NULL);

--- a/BoundaryMode.h
+++ b/BoundaryMode.h
@@ -107,7 +107,9 @@
 // budgets (e.g. EU868 = 1.0% long-term).
 #define ADDR_CONF_ST_AL         0x14F // Short-term airtime limit (1 byte, percent * 10)
 #define ADDR_CONF_LT_AL         0x150 // Long-term  airtime limit (1 byte, percent * 10)
-// Total: 0x151 (337 bytes — extends beyond 256-byte CONFIG area into
+#define ADDR_CONF_MDNS_EN       0x151 // mDNS enable flag (1 byte; 0x73 = enabled, 0xFF = unset/default-enabled)
+#define ADDR_CONF_MDNS_NAME     0x152 // Custom mDNS hostname (33 bytes, null-terminated; empty = auto)
+// Total: 0x173 (371 bytes — extends beyond 256-byte CONFIG area into
 //         unused EEPROM gap; safe on ESP32 where EEPROM starts at 824)
 
 #define BOUNDARY_ENABLE_BYTE 0x73
@@ -150,6 +152,14 @@ struct BoundaryState {
     // Mirrored into the global st_airtime_limit / lt_airtime_limit at boot.
     float    st_airtime_limit; // ~15 second rolling window
     float    lt_airtime_limit; // ~1 hour rolling window
+
+    // mDNS / Bonjour service. When disabled, the device publishes nothing on
+    // multicast and is only reachable by IP. Enabled by default.
+    bool     mdns_enabled;
+    // Custom mDNS hostname. Empty string = auto-generated `rtnode<XXXX>` from
+    // the last 4 hex chars of the device MAC. Validated to RFC-952 plus
+    // hyphen/digit at save time.
+    char     mdns_hostname[33];
 
     // Runtime state
     bool     wifi_connected;
@@ -237,6 +247,8 @@ inline void boundary_load_config() {
         boundary_state.advert_lon = 0.0;
         boundary_state.advert_jitter = false;
         boundary_state.node_name[0] = '\0';
+        boundary_state.mdns_enabled = true;
+        boundary_state.mdns_hostname[0] = '\0';
         boundary_state.st_airtime_limit = 0.0f;
         boundary_state.lt_airtime_limit = 0.0f;
         st_airtime_limit = 0.0f;
@@ -362,6 +374,20 @@ inline void boundary_load_config() {
         lt_airtime_limit = boundary_state.lt_airtime_limit;
     }
 
+    // mDNS enable flag — enabled unless explicitly disabled (0xFF = unset = enabled).
+    {
+        uint8_t mdns_en_byte = EEPROM.read(config_addr(ADDR_CONF_MDNS_EN));
+        boundary_state.mdns_enabled =
+            (mdns_en_byte == BOUNDARY_ENABLE_BYTE || mdns_en_byte == 0xFF);
+    }
+
+    // Custom mDNS hostname (33 bytes, null-terminated; 0xFF = unset = empty).
+    for (int i = 0; i < 32; i++) {
+        boundary_state.mdns_hostname[i] = EEPROM.read(config_addr(ADDR_CONF_MDNS_NAME + i));
+        if (boundary_state.mdns_hostname[i] == (char)0xFF) boundary_state.mdns_hostname[i] = '\0';
+    }
+    boundary_state.mdns_hostname[32] = '\0';
+
     // Reset runtime state
     boundary_state.packets_bridged_lora_to_tcp = 0;
     boundary_state.packets_bridged_tcp_to_lora = 0;
@@ -436,6 +462,16 @@ inline void boundary_save_config() {
         EEPROM.write(config_addr(ADDR_CONF_ST_AL), st_byte);
         EEPROM.write(config_addr(ADDR_CONF_LT_AL), lt_byte);
     }
+
+    // mDNS enable flag
+    EEPROM.write(config_addr(ADDR_CONF_MDNS_EN),
+                 boundary_state.mdns_enabled ? BOUNDARY_ENABLE_BYTE : 0x00);
+
+    // Custom mDNS hostname
+    for (int i = 0; i < 32; i++) {
+        EEPROM.write(config_addr(ADDR_CONF_MDNS_NAME + i), boundary_state.mdns_hostname[i]);
+    }
+    EEPROM.write(config_addr(ADDR_CONF_MDNS_NAME + 32), 0x00);
 
     EEPROM.write(config_addr(ADDR_CONF_APP_MARKER0), BOUNDARY_APP_MARKER0);
     EEPROM.write(config_addr(ADDR_CONF_APP_MARKER1), BOUNDARY_APP_MARKER1);

--- a/Display.h
+++ b/Display.h
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "Graphics.h"
+#include "MdnsService.h"
 #include <Adafruit_GFX.h>
 
 #if BOARD_MODEL != BOARD_TECHO
@@ -69,6 +70,10 @@ struct BoundaryState {
     // Airtime / duty-cycle limits as fraction (0.0 = disabled, 0.01 = 1%).
     float    st_airtime_limit; // ~15 second rolling window
     float    lt_airtime_limit; // ~1 hour rolling window
+    // mDNS / Bonjour publishing (default-enabled).
+    bool     mdns_enabled;
+    // Custom mDNS hostname (empty = auto-generated `rtnode<XXXX>`).
+    char     mdns_hostname[33];
     bool     wifi_connected;
     bool     tcp_connected;       // Backbone (WAN) connected
     bool     ap_tcp_connected;    // Local TCP server (LAN) has client
@@ -977,22 +982,50 @@ void draw_disp_area() {
       // 1px separator after SF line
       disp_area.drawLine(0, 34, disp_area.width()-1, 34, SSD1306_WHITE);
 
-      // WiFi IP address
-      disp_area.setCursor(2, 44);
-      if (boundary_state.wifi_connected) {
-        disp_area.print(wr_device_ip);
+      // When mDNS is enabled we show three slightly-tighter rows in the lower
+      // area: hostname, IP, port — and drop the bottom separator line to free
+      // the third row. When mDNS is disabled we keep the original two-row
+      // layout (IP, Port + separator).
+      if (boundary_state.mdns_enabled) {
+        // Row 1: mDNS hostname. Resolve at draw time so the displayed value
+        // matches whatever start_sta_auto() actually published.
+        uint8_t mac[6];
+        WiFi.macAddress(mac);
+        char suffix[5];
+        snprintf(suffix, sizeof(suffix), "%02x%02x", mac[4], mac[5]);
+        char host[33];
+        mdns_service::resolve_hostname(boundary_state.mdns_hostname, suffix,
+                                       host, sizeof(host));
+        disp_area.setCursor(2, 42);
+        disp_area.printf("%s.local", host);
+
+        // Row 2: WiFi IP
+        disp_area.setCursor(2, 52);
+        if (boundary_state.wifi_connected) {
+          disp_area.print(wr_device_ip);
+        } else {
+          disp_area.print("No WiFi");
+        }
+
+        // Row 3: Local TCP server port (shown only when enabled)
+        disp_area.setCursor(2, 62);
+        if (boundary_state.ap_tcp_enabled) {
+          disp_area.printf("Port:%u", boundary_state.ap_tcp_port);
+        }
       } else {
-        disp_area.print("No WiFi");
+        // Original two-row layout — IP, Port, separator.
+        disp_area.setCursor(2, 44);
+        if (boundary_state.wifi_connected) {
+          disp_area.print(wr_device_ip);
+        } else {
+          disp_area.print("No WiFi");
+        }
+        disp_area.setCursor(2, 55);
+        if (boundary_state.ap_tcp_enabled) {
+          disp_area.printf("Port:%u", boundary_state.ap_tcp_port);
+        }
+        disp_area.drawLine(0, 60, disp_area.width()-1, 60, SSD1306_WHITE);
       }
-
-      // Local TCP server port (shown only when enabled)
-      disp_area.setCursor(2, 55);
-      if (boundary_state.ap_tcp_enabled) {
-        disp_area.printf("Port:%u", boundary_state.ap_tcp_port);
-      }
-
-      // 1px separator after Port line
-      disp_area.drawLine(0, 60, disp_area.width()-1, 60, SSD1306_WHITE);
 #else
       if (radio_online && display_diagnostics) {
 #ifdef HAS_RNS

--- a/MdnsService.h
+++ b/MdnsService.h
@@ -1,0 +1,128 @@
+// mDNS / zeroconf service for RTNode
+//
+// Publishes the node's STA hostname and a `_reticulum._tcp` service so peers
+// on the same LAN can discover the local TCP server without a static IP or
+// router DHCP reservation. In config-portal AP mode publishes a fixed name
+// (`rnode-setup.local`) so the captive portal can be reached by name.
+//
+// Header-only; safe to include from multiple translation units thanks to the
+// `inline` linkage and a single static state variable per build.
+
+#pragma once
+
+#include <ESPmDNS.h>
+#include <WiFi.h>
+
+namespace mdns_service {
+
+inline bool& running_ref() {
+    static bool running = false;
+    return running;
+}
+
+// Normalize a hostname for mDNS: lowercase ASCII, replace anything outside
+// [a-z0-9-] with '-'. Writes at most `out_size-1` chars + NUL into `out`.
+inline void normalize_hostname(const char* in, char* out, size_t out_size) {
+    if (out_size == 0) return;
+    size_t j = 0;
+    for (size_t i = 0; in[i] != 0 && j + 1 < out_size; ++i) {
+        char c = in[i];
+        if (c >= 'A' && c <= 'Z') c = c - 'A' + 'a';
+        bool ok = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-';
+        out[j++] = ok ? c : '-';
+    }
+    out[j] = 0;
+}
+
+// Resolve the effective mDNS hostname: honor `custom` if non-empty, otherwise
+// fall back to `rtnode<XXXX>` where XXXX = `default_suffix` (typically the
+// last 4 hex chars of the device MAC). Output is normalized.
+inline void resolve_hostname(const char* custom, const char* default_suffix,
+                             char* out, size_t out_size) {
+    if (custom != nullptr && custom[0] != 0) {
+        normalize_hostname(custom, out, out_size);
+    } else {
+        char fallback[16];
+        snprintf(fallback, sizeof(fallback), "rtnode%s",
+                 default_suffix != nullptr ? default_suffix : "");
+        normalize_hostname(fallback, out, out_size);
+    }
+}
+
+// Start mDNS in STA mode and (optionally) advertise the local TCP server.
+// `hostname` is the .local name — case and stray chars are normalized.
+// `tcp_port == 0` means "do not advertise the _reticulum._tcp service".
+inline bool start_sta(const char* hostname, uint16_t tcp_port) {
+    bool& running = running_ref();
+    if (running) return true;
+    if (hostname == nullptr || hostname[0] == 0) return false;
+    if (WiFi.status() != WL_CONNECTED) return false;
+
+    char norm[32];
+    normalize_hostname(hostname, norm, sizeof(norm));
+    if (norm[0] == 0) return false;
+
+    if (!MDNS.begin(norm)) {
+        Serial.println("[mDNS] begin() failed in STA mode");
+        return false;
+    }
+    if (tcp_port != 0) {
+        MDNS.addService("reticulum", "tcp", tcp_port);
+        MDNS.addServiceTxt("reticulum", "tcp", "kind", "rtnode-heltec");
+    }
+    running = true;
+    Serial.print("[mDNS] STA up: ");
+    Serial.print(norm);
+    Serial.print(".local");
+    if (tcp_port != 0) {
+        Serial.print(" (_reticulum._tcp port ");
+        Serial.print(tcp_port);
+        Serial.print(")");
+    }
+    Serial.println();
+    return true;
+}
+
+// Start mDNS in AP mode for the config portal. Hostname is fixed so users can
+// always type the same .local address regardless of which device they are
+// configuring.
+inline bool start_ap_config(const char* hostname) {
+    bool& running = running_ref();
+    if (running) return true;
+    if (hostname == nullptr || hostname[0] == 0) return false;
+
+    if (!MDNS.begin(hostname)) {
+        Serial.println("[mDNS] begin() failed in AP mode");
+        return false;
+    }
+    MDNS.addService("http", "tcp", 80);
+    running = true;
+    Serial.print("[mDNS] AP up: ");
+    Serial.print(hostname);
+    Serial.println(".local");
+    return true;
+}
+
+// Convenience: derive the MAC-suffix fallback automatically and start the STA
+// service. Equivalent to manually calling resolve_hostname() + start_sta().
+inline bool start_sta_auto(const char* custom, uint16_t tcp_port) {
+    uint8_t mac[6];
+    WiFi.macAddress(mac);
+    char suffix[5];
+    snprintf(suffix, sizeof(suffix), "%02x%02x", mac[4], mac[5]);
+    char name[33];
+    resolve_hostname(custom, suffix, name, sizeof(name));
+    return start_sta(name, tcp_port);
+}
+
+inline void stop() {
+    bool& running = running_ref();
+    if (!running) return;
+    MDNS.end();
+    running = false;
+    Serial.println("[mDNS] stopped");
+}
+
+inline bool is_running() { return running_ref(); }
+
+}  // namespace mdns_service

--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ The config portal activates automatically on:
 - **First boot** — when no saved configuration exists
 - **Button hold >5 seconds** — hold the PRG button for 5+ seconds, the device reboots into config mode
 
-When active, the device creates a WiFi access point named **`RNode-Boundary-Setup`** (open network). A captive portal should appear automatically when you connect; if not, browse to `http://192.168.4.1`.
+When active, the device creates a WiFi access point named **`RNode-Boundary-Setup`** (open network). A captive portal should appear automatically when you connect; if not, browse to `http://10.0.0.1` or, on systems with mDNS support, `http://rtnode.local`. (This config-mode hostname is fixed and shared by every device, so it's always the same regardless of how you later name the unit in normal operation.)
 
 ### Config Page Options
 
-The web form has four sections:
+The web form has the following sections:
 
 #### 📶 WiFi Network
 | Field | Description |
@@ -170,6 +170,14 @@ The web form has four sections:
 |-------|-------------|
 | **Local TCP Server** | Enable/Disable — runs a TCP server on your WiFi for local Reticulum nodes to connect |
 | **TCP Port** | Port to listen on (default: `4242`) |
+
+#### 🌐 Local Network Name (mDNS)
+Publishes the device on the local network via mDNS / Bonjour, so it can be reached as `<hostname>.local` from any computer in the same LAN — no IP lookup or DHCP reservation required. The Local TCP Server (if enabled) is also advertised as a `_reticulum._tcp` service for auto-discovery by Reticulum-aware tools.
+
+| Field | Description |
+|-------|-------------|
+| **mDNS** | Enable/Disable — when disabled, the device suppresses all multicast announcements |
+| **Hostname** | Custom hostname (lowercase, digits, hyphens; first/last char must be alphanumeric). Leave blank for the default `rtnode<XXXX>` where `XXXX` is the last 4 hex chars of the device MAC |
 
 #### 📻 LoRa Radio
 | Field | Description |
@@ -228,13 +236,15 @@ The 128×64 OLED is split into two panels:
 
 ```
  ▓▓ RTNode-HV4 ▓▓  ← title bar (inverted)
- 867.200MHz       ← LoRa frequency
- SF7 125k         ← spreading factor & bandwidth
+ 867.200MHz        ← LoRa frequency
+ SF7 125k          ← spreading factor & bandwidth
  ────────────────  ← separator
- 192.168.1.42     ← WiFi IP address (or "No WiFi")
- Port:4242        ← Local TCP server port
- ────────────────  ← separator
+ rtnode.local      ← mDNS hostname (only when mDNS enabled)
+ 192.168.1.42      ← WiFi IP address (or "No WiFi")
+ Port:4242         ← Local TCP server port
 ```
+
+When mDNS is **disabled** in configuration, the hostname row is omitted and a 1-pixel separator is drawn under the Port row instead — preserving the original two-row layout.
 
 - **Port** shows the Local TCP server port (the port local nodes connect to), not the backbone port
 - **Port line is hidden** when the Local TCP Server is disabled
@@ -364,9 +374,11 @@ On your server, configure `rnsd` with a TCP Client Interface:
 [interfaces]
   [[TCP Client to Transport Node]]
     type = TCPClientInterface
-    target_host = <transport-node-ip>
+    target_host = <transport-node-ip-or-mdns-name>
     target_port = 4242
 ```
+
+`target_host` accepts either an IP (e.g. `192.168.1.42`) or, on systems with mDNS support, the device's `.local` name (e.g. `rtnode.local`, or the custom hostname you set in the configuration portal). The mDNS name is the easier choice — it survives DHCP lease changes without a router-side reservation.
 
 Set the transport node's **Local TCP Server** to **Enabled** (port 4242).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project was primarily developed with the use of AI assistance.
   └──────────┘                │                                rmap.world)
                          LoRa Radio                                ▲
                               │            ┌──────────────┐  WiFi  │
-                       ◄── RF mesh ──────► │ RTNode-HV4  │ ◄─TCP──┘
+                       ◄── RF mesh ──────► │ RTNode-HV4   │ ◄─TCP──┘
                               │            │Transport Node│    ▲
                         Other RNodes       └──────────────┘    │
                                                            ┌───┴───┐

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -36,6 +36,7 @@
 #include "TcpInterface.h"
 #include "BoundaryConfig.h"
 #include "Advertise.h"
+#include "MdnsService.h"
 #include "esp_bt.h"
 #endif
 
@@ -910,6 +911,10 @@ void setup() {
         if (local_tcp_interface_ptr) {
           local_tcp_interface_ptr->start();
           HEAD("Boundary Mode: Local TCP server started", RNS::LOG_TRACE);
+        }
+        if (wifi_is_connected() && boundary_state.mdns_enabled) {
+          uint16_t advert_port = boundary_state.ap_tcp_enabled ? boundary_state.ap_tcp_port : 0;
+          mdns_service::start_sta_auto(boundary_state.mdns_hostname, advert_port);
         }
       } else if (boundary_state.wifi_enabled) {
         HEAD("Boundary Mode: Waiting for WiFi before starting TCP interfaces", RNS::LOG_WARNING);
@@ -2628,6 +2633,16 @@ void loop() {
 
   #if HAS_WIFI
     if (wifi_initialized) update_wifi();
+    #ifdef BOUNDARY_MODE
+      // Late-start mDNS once WiFi finishes its asynchronous association.
+      // The function early-exits if already running or WiFi is not yet up,
+      // so calling it every loop iteration is cheap.
+      if (!mdns_service::is_running() && wifi_is_connected() &&
+          boundary_state.wifi_enabled && boundary_state.mdns_enabled) {
+        uint16_t advert_port = boundary_state.ap_tcp_enabled ? boundary_state.ap_tcp_port : 0;
+        mdns_service::start_sta_auto(boundary_state.mdns_hostname, advert_port);
+      }
+    #endif
   #endif
 
   #if HAS_INPUT

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,7 +41,7 @@ build_flags =
 	;-DCONFIG_LOG_DEFAULT_LEVEL=5
 lib_deps = 
 	ArduinoJson@^7.4.2
-	MsgPack@^0.4.2
+	hideakitai/MsgPack@^0.4.2
 	adafruit/Adafruit SSD1306@^2.5.9
 	https://github.com/attermann/Crypto.git
 ; Exclude directories in root from sources


### PR DESCRIPTION
## Summary

Adds mDNS / Bonjour publishing so the device is reachable as `<hostname>.local` from any machine on the same LAN, without needing a static IP or a router-side DHCP reservation. The Local TCP Server (when enabled) is also advertised as a `_reticulum._tcp` service for auto-discovery by Reticulum-aware tooling.

In configuration-portal AP mode the captive portal is reachable as `rtnode.local`, removing the need to remember `10.0.0.1`.

## Motivation

Right now the only way to point an external `rnsd` (or Sideband) at a transport node's Local TCP Server is to look the address up in the router admin and either set up a DHCP reservation or hard-code the lease. Both break the moment the lease changes hands or the user moves to a different network. mDNS solves it with a stable, human-readable name.

## What's in the patch

### Configuration portal

New **Local Network Name (mDNS)** section:
- **mDNS** — Enable / Disable (default Enabled). When disabled, the device suppresses *all* multicast announcements and is only reachable by IP.
- **Hostname** — optional custom hostname. Empty falls back to `rtnode<XXXX>` where `XXXX` is the last 4 hex chars of the device MAC. Input is normalised to lowercase + `[a-z0-9-]` and stripped of leading/trailing hyphens before save.

### OLED display

When mDNS is enabled, the right-panel lower area shows three rows: hostname, IP, port. The previous bottom separator line is dropped to free the row.

When mDNS is disabled, the original two-row layout (IP + port + separator) is preserved unchanged.

### EEPROM additions

| Address | Size | Purpose |
|---------|------|---------|
| `0x151` | 1 byte | mDNS enable flag |
| `0x152` | 33 bytes | Custom hostname (null-terminated) |

Both default to "enabled / auto-generated name" when the bytes are unprogrammed (`0xFF`), so existing installations keep working without any factory reset.

### Implementation

mDNS itself is a thin header-only wrapper around `ESPmDNS` in `MdnsService.h`. It is started lazily from the main loop once WiFi finishes its asynchronous association, and torn down before switching the radio into config-portal AP mode so the ESPmDNS state never survives a WiFi mode change.

### Build fix (separate commit)

`platformio.ini` had `MsgPack@^0.4.2` which is now ambiguous between `hideakitai/MsgPack` and `mbed-yihui/msgpack` and stalls the Library Manager. Pinned to `hideakitai/MsgPack@^0.4.2` to keep the same version range while removing the prompt. This is its own commit so you can pick it up or skip it.

## Backwards compatibility

- New EEPROM bytes default to enabled-with-auto-name on uninitialised (`0xFF`) reads, so users who flash this build over an existing install get mDNS automatically without losing any saved settings.
- Users who don't want mDNS can disable it in the portal — the OLED layout reverts to the original look in that case.
- No changes to the LoRa, TCP backbone, or Local TCP Server code paths.

## Testing

Tested on a Heltec V4 (V4.3 revision):

- mDNS resolves `rtnode<XXXX>.local` from a Linux host (`avahi-resolve`, `getent hosts`)
- `_reticulum._tcp` service appears in `avahi-browse -art _reticulum._tcp` with the correct port and address
- `rnsd` connects to the Local TCP Server using the `.local` name as `target_host`
- Custom hostname round-trips through the portal save/load
- Disabling mDNS cleanly stops the service and reverts the OLED layout
- Config-portal AP mode reachable as `rtnode.local`

**Not tested on Heltec V3** — the implementation only touches the WiFi/Boundary path and uses standard ESPmDNS APIs supported on all ESP32-S3 board variants in this repo, so I expect it to work, but a V3 owner would need to confirm.

## Notes

- Routers with strict AP/client isolation or aggressive IGMP snooping may swallow the multicast and prevent resolution. This is an environmental thing, not a firmware bug — the same setting also blocks any other mDNS device on the network.
- mDNS adds roughly ~2 KB of flash and a few hundred bytes of heap. Did not observe any memory regressions on the V4 (16 MB / 2 MB PSRAM).
