### PR TITLE
Drop LoRa frames below HEADER_MINSIZE before forwarding (fixes LoadProhibited crash on short frames)

### DIFF
--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -1294,7 +1294,18 @@ inline void kiss_write_packet() {
     #endif
     data << byte;
   }
-  lora_interface.handle_incoming(data);
+  // FIX (community patch): drop frames below the RNS minimum header size instead of
+  // forwarding them. A malformed short frame (e.g. from RF collisions) that goes through
+  // the raw-shift path above and then the FIREWALL_MODE forward causes a NULL-pointer
+  // LoadProhibited panic. This mirrors the HEADER_MINSIZE check already enforced in
+  // Packet::unpack(), placed AFTER the raw-shift so genuinely byte-shifted valid frames
+  // (which become >= HEADER_MINSIZE after the prepend) are still recovered.
+  if (data.size() >= RNS::Type::Reticulum::HEADER_MINSIZE) {
+    lora_interface.handle_incoming(data);
+  } else {
+    VERBOSEF("[LoRa] RX dropped: %u bytes below HEADER_MINSIZE (%u)",
+        (unsigned)data.size(), (unsigned)RNS::Type::Reticulum::HEADER_MINSIZE);
+  }
   last_lora_phy_header_valid = false;
 #endif
 


### PR DESCRIPTION
## Problem

In `FIREWALL_MODE`, a malformed / short (below `HEADER_MINSIZE`, i.e. < 35 byte) LoRa frame that passes through the raw-shift path in `kiss_write_packet()` reaches the forwarding path (WL / FWD-CHECK -> destination lookup) and dereferences a NULL pointer, causing `Guru Meditation Error: Core 1 panic'ed (LoadProhibited)` and a reboot. Under RF-collision conditions (co-located radios on the same channel) these short frames recur, rebooting the node every few minutes; enough consecutive fast reboots can trip the config-portal fallback and wipe the stored config.

Crash signature (deterministic, same PC/backtrace every time): `PC 0x40056f5c`, `EXCCAUSE 0x1c`, `EXCVADDR 0x00000000`. Always immediately preceded by:

```
[LoRa] RX raw-shift fix: prepend 0x.. (hops byte was ..)
[LoRa] RX 26 bytes
WL#2 ADD - ........
FWD-CHECK - FROM: Interface[LoRaInterface] (LAN) TO: ........ (?) FWD
```

The library already enforces this minimum in `Packet::unpack()` (`raw.size() < HEADER_MINSIZE` throws), and a plain short frame that reaches `unpack()` is dropped correctly (`Received malformed packet, dropping it ... minimum header size of 35 bytes`). The problem is that the `FIREWALL_MODE` forward path reads the destination and forwards **before** that validation runs, so the raw-shift'd short frame crashes instead of being dropped.

## Fix

Guard `lora_interface.handle_incoming(data)` in `kiss_write_packet()` with a `data.size() >= RNS::Type::Reticulum::HEADER_MINSIZE` check, placed **after** the raw-shift so genuinely byte-shifted valid frames (which become >= HEADER_MINSIZE after the prepend) are still recovered. Reuses the library's own `HEADER_MINSIZE` constant, so it tracks the protocol minimum. Drops only frames RNS already considers invalid — no legitimate traffic is affected.

## Testing

- Builds clean for `rtnode_heltec_v3` (PlatformIO).
- Flashed to a Heltec V3 transport node writing only the app partition (config/identity preserved): boots and connects to the backbone normally, no config-portal fallback.
- Sub-header frames now hit the guard and are dropped (`[LoRa] RX dropped: N bytes below HEADER_MINSIZE`) instead of reaching the crashing forward path.

The identical code path exists in the fork `GrayHatGuy/RTNode-2400`.
