### PR TITLE
Fix compile error in nrf52 platform: 'sort' is not a member of 'std'

### DIFF
--- a/lib/microReticulum/src/Utilities/Persistence.h
+++ b/lib/microReticulum/src/Utilities/Persistence.h
@@ -13,6 +13,7 @@
 #include <deque>
 #include <set>
 #include <string>
+#include <algorithm>
 
 namespace ArduinoJson {
 


### PR DESCRIPTION
Add missing header to fix nrf52 platform compile

Tested Environments:
* rtnode_heltec_v4
* wiscore_rak4631

Host Platform: Win11