### PR TITLE
Throw exceptions by value, not by pointer

### DIFF
--- a/lib/microReticulum/src/Cryptography/Token.cpp
+++ b/lib/microReticulum/src/Cryptography/Token.cpp
@@ -84,7 +84,7 @@ const Bytes Token::encrypt(const Bytes& data) {
 		);
 	}
 	else {
-		throw new std::invalid_argument("Invalid token mode "+std::to_string(_mode));
+		throw std::invalid_argument("Invalid token mode "+std::to_string(_mode));
 	}
 	DEBUG("Token::encrypt: padded ciphertext length: " + std::to_string(ciphertext.size()));
 	TRACE("Token::encrypt: ciphertext: " + ciphertext.toHex());
@@ -140,7 +140,7 @@ const Bytes Token::decrypt(const Bytes& token) {
 			);
 		}
 		else {
-			throw new std::invalid_argument("Invalid token mode "+std::to_string(_mode));
+			throw std::invalid_argument("Invalid token mode "+std::to_string(_mode));
 		}
 		DEBUG("Token::encrypt: unpadded plaintext length: " + std::to_string(plaintext.size()));
 		TRACE("Token::decrypt: plaintext:  " + plaintext.toHex());

--- a/lib/microReticulum/src/Cryptography/Token.h
+++ b/lib/microReticulum/src/Cryptography/Token.h
@@ -26,7 +26,7 @@ namespace RNS { namespace Cryptography {
 		static inline const Bytes generate_key(RNS::Type::Cryptography::Token::token_mode mode = RNS::Type::Cryptography::Token::MODE_AES_256_CBC) {
 			if (mode == RNS::Type::Cryptography::Token::MODE_AES_128_CBC) return random(32);
 			else if (mode == RNS::Type::Cryptography::Token::MODE_AES_256_CBC) return random(64);
-			else throw new std::invalid_argument("Invalid token mode: " + std::to_string(mode));
+			else throw std::invalid_argument("Invalid token mode: " + std::to_string(mode));
 		}
 
 	public:

--- a/lib/microReticulum/src/Link.cpp
+++ b/lib/microReticulum/src/Link.cpp
@@ -253,7 +253,7 @@ void Link::handshake() {
 		uint16_t derived_key_length;
 		if (_object->_mode == RNS::Type::Link::MODE_AES128_CBC) derived_key_length = 32;
 		else if (_object->_mode == RNS::Type::Link::MODE_AES256_CBC) derived_key_length = 64;
-		else throw new std::invalid_argument("Invalid link mode "+std::to_string(_object->_mode)+" on "+toString());
+		else throw std::invalid_argument("Invalid link mode "+std::to_string(_object->_mode)+" on "+toString());
 
 		_object->_derived_key = Cryptography::hkdf(
 			derived_key_length,
@@ -1477,7 +1477,7 @@ RequestReceipt::RequestReceipt(const Link& link, const PacketReceipt& packet_rec
 		_object->_timeout = timeout;
 	}
 	else {
-		throw new std::invalid_argument("No timeout specified for request receipt");
+		throw std::invalid_argument("No timeout specified for request receipt");
 	}
 
 	_object->_callbacks._response = response_callback;


### PR DESCRIPTION
### Problem

Five sites throw a *pointer* to an exception rather than the exception itself:

- `lib/microReticulum/src/Cryptography/Token.cpp` (2 sites, in `encrypt` and `decrypt`)
- `lib/microReticulum/src/Cryptography/Token.h` (`generate_key`)
- `lib/microReticulum/src/Link.cpp` (2 sites)

`catch (const std::exception&)` does not match `std::invalid_argument*`, and nothing in the tree catches by pointer. So when one of these fires it bypasses every handler, unwinds to `std::terminate()` — which on ESP32 is a device reboot — and leaks the allocation on the way out.

### Origin

This is inherited rather than recent: the same form is present in the vendored microReticulum snapshot this fork is based on (attermann 0.2.4, which has `throw new` at these sites). Upstream attermann fixed it in **0.4.0**; this fork predates that re-vendor and still carries the older form.

### Solution

`throw new X(...)` → `throw X(...)` at all five sites. No behaviour change on any non-error path — the only difference is that these errors can now actually be caught.

**Compatibility:** nothing is affected. I checked the tree for `catch` clauses taking a pointer type and there are none, so no existing handler depended on the old behaviour.

**Testing:** compiled and running on 3 × Heltec V4 (ESP32-S3). No fault has been attributed to this change.

---

Found while porting upstream microReticulum changes into my fork. Like this project, my fork is developed with AI assistance under human direction — I've reviewed this change, and it's running on hardware as above.
